### PR TITLE
Add an option to group estimates by commit message content

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -2,6 +2,7 @@
 MIT License
 
 Copyright (c) 2019 Luigi Tanzini
+Copyright (c) 2021 Craig Adam
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -58,8 +58,13 @@ this will use default settings to compute the time spent on the repo at the spec
         if true will output estimates in JSON format
 -repo string
         git repository path. If no flag is specified the current folder is assumed (default ".")
--jira
-        if true will group estimates by tagged Jira issue
+-group
+        group estimates based on comment message content using a predefined or custom pattern. Custom patterns should identify exactly 1 capturing group. See https://github.com/google/re2/wiki/Syntax for syntax.
+        Predefined patterns available:
+    
+                jira - Captures the first Jira issue key based on the smart commit format (https://support.atlassian.com/bitbucket-cloud/docs/use-smart-commits/)
+                type - Captures the type component of conventional commit messages (https://www.conventionalcommits.org/en/v1.0.0/)
+                scope - Captures the scope component of conventional commit messages (https://www.conventionalcommits.org/en/v1.0.0/)
 ```
 
 ### Output
@@ -113,6 +118,14 @@ will output:
    }
 }
 ```
+
+### Grouping
+
+By default, commits are grouped by author email address. This can be further subgrouped based on content matching in the commit message. Specify a predefined pattern after the `-group` flag or provide a custom [regex pattern](https://github.com/google/re2/wiki/Syntax) with exactly 1 capture group.
+
+* `-group jira` - Captures the first Jira issue key based on the [smart commit format](https://support.atlassian.com/bitbucket-cloud/docs/use-smart-commits/)
+* `-group type` - Captures the type component of [conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/)
+* `-group scope` - Captures the scope component of [conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/)
 
 ## Estimates
 

--- a/README.md
+++ b/README.md
@@ -31,16 +31,20 @@ The code is written in plain go and uses [go-git](https://github.com/src-d/go-gi
 ## Install
 
 Clone the repository then simply build git-estimate from source using the goo tools:
+
 ```shell script
 cd path/to/your/cloned/repo
 go build git-estimate
 ```
 
 ## Usage
+
 At a minimum run:
+
 ```
 git-estimate -repo=/path/to/repo
 ```
+
 this will use default settings to compute the time spent on the repo at the specified path.
 
 ```
@@ -54,69 +58,79 @@ this will use default settings to compute the time spent on the repo at the spec
         if true will output estimates in JSON format
 -repo string
         git repository path. If no flag is specified the current folder is assumed (default ".")
+-jira
+        if true will group estimates by tagged Jira issue
 ```
 
 ### Output
 
 You can also specify the result to be output in JSON format, should you need to use the program in a pipeline.
+
 ```shell script
 git-estimate -repo=/path/to/repo -json
 ```
+
 will output:
+
 ```json5
-{ 
-   "developers":[ 
-      { 
-         "author":"dev1@decodica.com",
-         "hours":223.58805555555554,
-         "days":27.948506944444443
-      },
-      { 
-         "author":"luigi.tanzini@decodica.com",
-         "hours":2,
-         "days":0.25
-      },
-      { 
-         "author":"dev2@decodica.com",
-         "hours":4.006111111111111,
-         "days":0.5007638888888889
-      },
-      { 
-         "author":"dev3@decodica.com",
-         "hours":11.831944444444444,
-         "days":1.4789930555555555
-      },
-      { 
-         "author":"dev4@decodica.com",
-         "hours":2,
-         "days":0.25
-      },
-      { 
-         "author":"dev5@decodica.com",
-         "hours":81.23,
-         "days":10.15375
-      }
-   ],
-   "overall":{ 
-      "author":"all",
-      "hours":324.6561111111111,
-      "days":40.58201388888889
-   }
+{
+  developers: [
+    {
+      author: 'dev1@decodica.com',
+      hours: 223.58805555555554,
+      days: 27.948506944444443,
+    },
+    {
+      author: 'luigi.tanzini@decodica.com',
+      hours: 2,
+      days: 0.25,
+    },
+    {
+      author: 'dev2@decodica.com',
+      hours: 4.006111111111111,
+      days: 0.5007638888888889,
+    },
+    {
+      author: 'dev3@decodica.com',
+      hours: 11.831944444444444,
+      days: 1.4789930555555555,
+    },
+    {
+      author: 'dev4@decodica.com',
+      hours: 2,
+      days: 0.25,
+    },
+    {
+      author: 'dev5@decodica.com',
+      hours: 81.23,
+      days: 10.15375,
+    },
+  ],
+  overall: {
+    author: 'all',
+    hours: 324.6561111111111,
+    days: 40.58201388888889,
+  },
 }
 ```
 
 ## Estimates
+
 Currently the software supports two simple methods of estimation:
 
 #### Working Session
+
 This estimation is perhaps the most accurate.
 It assumes the following:
+
 - A "day" output is a working day made of 8 hours.
 - If more than 8 hours have passed between a commit and the next one, the former was the last commit of the session.
-- The *first* commit of each working session took 2 hours of work. You can configure this padding using the ```baseline``` flag when running *git-estimate*
-  
+- The _first_ commit of each working session took 2 hours of work. You can configure this padding using the `baseline` flag when running _git-estimate_
+
 #### Working Day
+
 This estimation assumes the following:
+
 - If a commit has been done during the day, that day counts toward the total
 - A day is made of 8 working hours
 
@@ -126,12 +140,11 @@ Feel free to contribute to the project however you want.
 
 The code should make it easy to add estimation methods and/or output formatter should you need different format or require additional estimation methods.
 
-Please use *go fmt* before a pull request.
+Please use _go fmt_ before a pull request.
 
 #### Inspiration
 
 The software was inspired by [git-hours](https://github.com/kimmobrunfeldt/git-hour). I wasn't able to find anything similar which required less tools to get started so I decided to hack together a quick software that would be as simple and straight to the point.
-
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -73,44 +73,44 @@ git-estimate -repo=/path/to/repo -json
 will output:
 
 ```json5
-{
-  developers: [
-    {
-      author: 'dev1@decodica.com',
-      hours: 223.58805555555554,
-      days: 27.948506944444443,
-    },
-    {
-      author: 'luigi.tanzini@decodica.com',
-      hours: 2,
-      days: 0.25,
-    },
-    {
-      author: 'dev2@decodica.com',
-      hours: 4.006111111111111,
-      days: 0.5007638888888889,
-    },
-    {
-      author: 'dev3@decodica.com',
-      hours: 11.831944444444444,
-      days: 1.4789930555555555,
-    },
-    {
-      author: 'dev4@decodica.com',
-      hours: 2,
-      days: 0.25,
-    },
-    {
-      author: 'dev5@decodica.com',
-      hours: 81.23,
-      days: 10.15375,
-    },
-  ],
-  overall: {
-    author: 'all',
-    hours: 324.6561111111111,
-    days: 40.58201388888889,
-  },
+{ 
+   "developers":[ 
+      { 
+         "author":"dev1@decodica.com",
+         "hours":223.58805555555554,
+         "days":27.948506944444443
+      },
+      { 
+         "author":"luigi.tanzini@decodica.com",
+         "hours":2,
+         "days":0.25
+      },
+      { 
+         "author":"dev2@decodica.com",
+         "hours":4.006111111111111,
+         "days":0.5007638888888889
+      },
+      { 
+         "author":"dev3@decodica.com",
+         "hours":11.831944444444444,
+         "days":1.4789930555555555
+      },
+      { 
+         "author":"dev4@decodica.com",
+         "hours":2,
+         "days":0.25
+      },
+      { 
+         "author":"dev5@decodica.com",
+         "hours":81.23,
+         "days":10.15375
+      }
+   ],
+   "overall":{ 
+      "author":"all",
+      "hours":324.6561111111111,
+      "days":40.58201388888889
+   }
 }
 ```
 
@@ -125,7 +125,7 @@ It assumes the following:
 
 - A "day" output is a working day made of 8 hours.
 - If more than 8 hours have passed between a commit and the next one, the former was the last commit of the session.
-- The _first_ commit of each working session took 2 hours of work. You can configure this padding using the `baseline` flag when running _git-estimate_
+- The *first* commit of each working session took 2 hours of work. You can configure this padding using the ```baseline``` flag when running *git-estimate*
 
 #### Working Day
 
@@ -140,7 +140,7 @@ Feel free to contribute to the project however you want.
 
 The code should make it easy to add estimation methods and/or output formatter should you need different format or require additional estimation methods.
 
-Please use _go fmt_ before a pull request.
+Please use *go fmt* before a pull request.
 
 #### Inspiration
 

--- a/estimate/day.go
+++ b/estimate/day.go
@@ -1,6 +1,8 @@
 package estimate
 
 import (
+	"fmt"
+	"strings"
 	"time"
 )
 
@@ -9,9 +11,14 @@ type DayEstimate struct{}
 func (d DayEstimate) Estimate(byAuthors map[string][]time.Time) []Result {
 	results := make([]Result, len(byAuthors))
 	c := 0
-	for k, _ := range byAuthors {
+	for k := range byAuthors {
 		r := &results[c]
 		r.Author = k
+		if strings.Count(k, "@") > 1 {
+			p := strings.Split(k, "@")
+			r.Author = fmt.Sprintf("%s@%s", p[0], p[1])
+			r.Issue = p[2]
+		}
 		prev := time.Time{}
 		v := byAuthors[k]
 		for _, t := range v {

--- a/estimate/day.go
+++ b/estimate/day.go
@@ -17,7 +17,7 @@ func (d DayEstimate) Estimate(byAuthors map[string][]time.Time) []Result {
 		if strings.Count(k, "@") > 1 {
 			p := strings.Split(k, "@")
 			r.Author = fmt.Sprintf("%s@%s", p[0], p[1])
-			r.Issue = p[2]
+			r.Group = p[2]
 		}
 		prev := time.Time{}
 		v := byAuthors[k]

--- a/estimate/estimate.go
+++ b/estimate/estimate.go
@@ -10,7 +10,7 @@ import (
 
 type Result struct {
 	Author string  `json:"author"`
-	Issue  string  `json:"issue,omitempty"`
+	Group  string  `json:"group,omitempty"`
 	Hours  float64 `json:"hours"`
 	Days   float64 `json:"days"`
 }
@@ -56,8 +56,8 @@ func (f StringFormatter) String(results []Result) string {
 	var builder strings.Builder
 	for _, res := range results {
 		builder.WriteString(fmt.Sprintf("commits by %s", res.Author))
-		if res.Issue != "" {
-			builder.WriteString(fmt.Sprintf(" on %s", res.Issue))
+		if res.Group != "" {
+			builder.WriteString(fmt.Sprintf(" on %s", res.Group))
 		}
 		builder.WriteString(fmt.Sprintf("\n=== %.2f days (%.2f hours)", res.Days, res.Hours))
 		builder.WriteString("\n\n")

--- a/estimate/estimate.go
+++ b/estimate/estimate.go
@@ -10,6 +10,7 @@ import (
 
 type Result struct {
 	Author string  `json:"author"`
+	Issue  string  `json:"issue,omitempty"`
 	Hours  float64 `json:"hours"`
 	Days   float64 `json:"days"`
 }
@@ -55,6 +56,9 @@ func (f StringFormatter) String(results []Result) string {
 	var builder strings.Builder
 	for _, res := range results {
 		builder.WriteString(fmt.Sprintf("commits by %s", res.Author))
+		if res.Issue != "" {
+			builder.WriteString(fmt.Sprintf(" on %s", res.Issue))
+		}
 		builder.WriteString(fmt.Sprintf("\n=== %.2f days (%.2f hours)", res.Days, res.Hours))
 		builder.WriteString("\n\n")
 		total.Hours += res.Hours

--- a/estimate/session.go
+++ b/estimate/session.go
@@ -21,7 +21,7 @@ func (ws WorkingSession) Estimate(byAuthors map[string][]time.Time) []Result {
 		if strings.Count(k, "@") > 1 {
 			p := strings.Split(k, "@")
 			r.Author = fmt.Sprintf("%s@%s", p[0], p[1])
-			r.Issue = p[2]
+			r.Group = p[2]
 		}
 		next := time.Time{}
 		v := byAuthors[k]

--- a/estimate/session.go
+++ b/estimate/session.go
@@ -1,6 +1,8 @@
 package estimate
 
 import (
+	"fmt"
+	"strings"
 	"time"
 )
 
@@ -13,9 +15,14 @@ type WorkingSession struct {
 func (ws WorkingSession) Estimate(byAuthors map[string][]time.Time) []Result {
 	results := make([]Result, len(byAuthors))
 	c := 0
-	for k, _ := range byAuthors {
+	for k := range byAuthors {
 		r := &results[c]
 		r.Author = k
+		if strings.Count(k, "@") > 1 {
+			p := strings.Split(k, "@")
+			r.Author = fmt.Sprintf("%s@%s", p[0], p[1])
+			r.Issue = p[2]
+		}
 		next := time.Time{}
 		v := byAuthors[k]
 		for _, t := range v {
@@ -35,7 +42,6 @@ func (ws WorkingSession) Estimate(byAuthors map[string][]time.Time) []Result {
 
 		// add the last/first padding to the commit
 		r.Hours += (time.Duration(ws.Baseline) * time.Hour).Hours()
-
 
 		r.Days = r.Hours / 8.0
 		c++

--- a/main.go
+++ b/main.go
@@ -14,8 +14,11 @@ import (
 )
 
 const (
-	estSession = "session"
-	estDay     = "day"
+	estSession   = "session"
+	estDay       = "day"
+	jiraPattern  = "jira"
+	typePattern  = "type"
+	scopePattern = "scope"
 )
 
 const timeArgsLayout = "2006-01-02T15-04"
@@ -28,7 +31,13 @@ func main() {
 
 	json := flag.Bool("json", false, "if true will output estimates in JSON format")
 
-	jira := flag.Bool("jira", false, "if true will group estimates by tagged Jira issue")
+	group := flag.String("group", "", "group estimates based on comment message content using a predefined or custom pattern. "+
+		"Custom patterns should identify exactly 1 capturing group. See https://github.com/google/re2/wiki/Syntax for syntax.\n"+
+		"Predefined patterns available:\n"+
+		"\n\tjira - Captures the first Jira issue key based on the smart commit format (https://support.atlassian.com/bitbucket-cloud/docs/use-smart-commits/)"+
+		"\n\ttype - Captures the type component of conventional commit messages (https://www.conventionalcommits.org/en/v1.0.0/)"+
+		"\n\tscope - Captures the scope component of conventional commit messages (https://www.conventionalcommits.org/en/v1.0.0/)"+
+		"\n")
 
 	baseline := flag.Float64("baseline", 2.0, "baseline value for session estimate")
 
@@ -45,13 +54,34 @@ func main() {
 	case estDay:
 		est = estimate.DayEstimate{}
 	default:
-		fmt.Printf("invalid estimation method. Accepted values are %q and %q", estSession, estDay)
+		fmt.Printf("Invalid estimation method. Accepted values are %q and %q", estSession, estDay)
 		os.Exit(1)
 	}
 
 	if err != nil {
-		fmt.Printf("error opening repository at %s: %s", *path, err.Error())
+		fmt.Printf("Error opening repository at %s: %s", *path, err.Error())
 		os.Exit(1)
+	}
+
+	var re *regexp.Regexp
+
+	switch *group {
+	case jiraPattern:
+		re = regexp.MustCompile("(?:[\\w:]+ )?([a-zA-Z]\\w+-\\d+)\\D")
+	case typePattern:
+		re = regexp.MustCompile("^([a-zA-Z!]+)[\\(:]")
+	case scopePattern:
+		re = regexp.MustCompile("^[^\\()]+\\(([^\\)]+)\\)")
+	case "":
+		fmt.Printf("Invalid grouping pattern. Provide a custom pattern or specify a valid preset pattern: %q", jiraPattern)
+		os.Exit(1)
+	default:
+		re = regexp.MustCompile(*group)
+		caps := re.NumSubexp()
+		if caps == 0 || caps > 1 {
+			fmt.Printf("Invalid grouping pattern. Pattern must specify exactly 1 capture group")
+			os.Exit(1)
+		}
 	}
 
 	// get the commit history
@@ -60,25 +90,20 @@ func main() {
 		// parse the string
 		start, err = time.Parse(timeArgsLayout, *from)
 		if err != nil {
-			fmt.Printf("unable to parse 'from' %s given. %s", *from, err.Error())
+			fmt.Printf("Unable to parse 'from' %s given. %s", *from, err.Error())
 			os.Exit(1)
 		}
 	}
 
 	iter, err := repo.Log(&git.LogOptions{All: true, Order: git.LogOrderCommitterTime})
 	if err != nil {
-		fmt.Printf("error reading log of repository: %s", err.Error())
+		fmt.Printf("Error reading log of repository: %s", err.Error())
 		os.Exit(1)
 	}
 
 	defer iter.Close()
 
 	byAuthors := make(map[string][]time.Time)
-
-	// Jira smart commit format
-	// <ignored text> <ISSUE_KEY> <ignored text> #<COMMAND> <optional COMMAND_ARGUMENTS>
-	var re *regexp.Regexp
-	re = regexp.MustCompile("(?:[\\w:]+ )?([a-zA-Z]\\w+-\\d+)\\D")
 
 	// first group commits by authors, then for each author count the working days
 	if err := iter.ForEach(func(commit *object.Commit) error {
@@ -91,7 +116,7 @@ func main() {
 		var builder strings.Builder
 		builder.WriteString(commit.Author.Email)
 
-		if *jira {
+		if *group != "" {
 			matches := re.FindStringSubmatch(commit.Message)
 			if len(matches) > 1 {
 				builder.WriteString("@")
@@ -99,19 +124,19 @@ func main() {
 			}
 		}
 
-		group := builder.String()
+		key := builder.String()
 
-		sl, ok := byAuthors[group]
+		sl, ok := byAuthors[key]
 		if !ok {
 			sl = make([]time.Time, 0)
 		}
 
 		sl = append(sl, when)
-		byAuthors[group] = sl
+		byAuthors[key] = sl
 
 		return nil
 	}); err != nil {
-		fmt.Printf("error reading commits: %s", err.Error())
+		fmt.Printf("Error reading commits: %s", err.Error())
 		os.Exit(1)
 	}
 

--- a/main.go
+++ b/main.go
@@ -64,23 +64,31 @@ func main() {
 	}
 
 	var re *regexp.Regexp
+	groupSet := false
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == "group" {
+			groupSet = true
+		}
+	})
 
-	switch *group {
-	case jiraPattern:
-		re = regexp.MustCompile("(?:[\\w:]+ )?([a-zA-Z]\\w+-\\d+)\\D")
-	case typePattern:
-		re = regexp.MustCompile("^([a-zA-Z!]+)[\\(:]")
-	case scopePattern:
-		re = regexp.MustCompile("^[^\\()]+\\(([^\\)]+)\\)")
-	case "":
-		fmt.Printf("Invalid grouping pattern. Provide a custom pattern or specify a valid preset pattern: %q", jiraPattern)
-		os.Exit(1)
-	default:
-		re = regexp.MustCompile(*group)
-		caps := re.NumSubexp()
-		if caps == 0 || caps > 1 {
-			fmt.Printf("Invalid grouping pattern. Pattern must specify exactly 1 capture group")
+	if groupSet {
+		switch *group {
+		case jiraPattern:
+			re = regexp.MustCompile("(?:[\\w:]+ )?([a-zA-Z]\\w+-\\d+)\\D")
+		case typePattern:
+			re = regexp.MustCompile("^([a-zA-Z!]+)[\\(:]")
+		case scopePattern:
+			re = regexp.MustCompile("^[^\\()]+\\(([^\\)]+)\\)")
+		case "":
+			fmt.Printf("Invalid grouping pattern. Provide a custom pattern or specify a valid preset pattern: %q", jiraPattern)
 			os.Exit(1)
+		default:
+			re = regexp.MustCompile(*group)
+			caps := re.NumSubexp()
+			if caps == 0 || caps > 1 {
+				fmt.Printf("Invalid grouping pattern. Pattern must specify exactly 1 capture group")
+				os.Exit(1)
+			}
 		}
 	}
 


### PR DESCRIPTION
Some teams use [Jira smart commits](https://support.atlassian.com/bitbucket-cloud/docs/use-smart-commits/) to associate git commits with specific issues. Combined with time estimation, this makes it a lot easier to roll up time spent by dev on a given story/epic/etc.

This adds a command-line flag (`-group`) that will use a regexp pattern to extract a single capture group from the commit message to use to further group estimates. If the pattern is matched, the capture group is appended to the email address separated by a second `@` (which is not valid in an email and therefore should be reasonably safe as a delimiter). The estimators (session, day) check for the presence of a second `@` and if it's there, chop off the last one to use as the value for `Issue` in the result entry. Finally, the string formatter has been updated to report the issue key, if present.

I've included three predefined patterns for grouping. `jira` for grouping based on Jira smart commit messages (my original motivation), as well as `type` and `scope` for grouping based on either the type or scope as defined in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/). Users can also specify arbitrary custom patterns, provided they're valid regexp strings that specify exactly one capture group.